### PR TITLE
Example of drive filterin

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -93,16 +93,22 @@ public class Robot extends TimedRobot {
         return null;
     }
      public void teleopPeriodic(){
+         ///this stuff doesnt go here
           SmartDashboard.putNumber("Joystick X", m_driveStick.getX());
           SmartDashboard.putNumber("Joystick Y", m_driveStick.getY());
           SmartDashboard.putNumber("Joystick Z", m_driveStick.getZ());
 
           //lock out z twist unless button is pressed
+          //i can imagine having a filter chain instead of hard-coding it like
+          //this.
           twistLockFilter.setEnabled(! turnButton.get());
           
+          //note here that robotDrive.drive(readJoystickDriveCommand()) would work too!
           robotDrive.drive(twistLockFilter.filter(readJoystickDriveCommand(), getRobotPose()));
           
           Scheduler.getInstance().run();
+          
+          //neither does this stuff
           SmartDashboard.putNumber("Get Z", m_driveStick.getZ());
           SmartDashboard.putNumber("Thumb Speed", thumbs.getDesiredSpeed());
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -89,9 +89,11 @@ public class Robot extends TimedRobot {
         return new DriveCommand(m_driveStick.getX(),-m_driveStick.getY(),m_driveStick.getZ());
     }
 
+    //obviously this doesnt work-- i'd propose getting it from somewhere else
     protected RobotPose getRobotPose(){
         return null;
     }
+    
      public void teleopPeriodic(){
          ///this stuff doesnt go here
           SmartDashboard.putNumber("Joystick X", m_driveStick.getX());

--- a/src/main/java/frc/robot/core/RobotPose.java
+++ b/src/main/java/frc/robot/core/RobotPose.java
@@ -1,4 +1,4 @@
-package frc.robot.subsystems;
+package frc.robot.core;
 
 /**
  * The robot pose, relative to some reference frame

--- a/src/main/java/frc/robot/subsystems/AlignController.java
+++ b/src/main/java/frc/robot/subsystems/AlignController.java
@@ -1,5 +1,7 @@
 package frc.robot.subsystems;
 
+import frc.robot.core.RobotPose;
+
 /**
  * Generates output that aligns the robot 
  * left-to-right based on sensor input

--- a/src/main/java/frc/robot/subsystems/AlignController.java
+++ b/src/main/java/frc/robot/subsystems/AlignController.java
@@ -10,25 +10,18 @@ package frc.robot.subsystems;
  * output: x and y control signals for drive
  * @author dcowden
  */
-public class AlignController implements DriveFilter{
+public class AlignController extends DriveFilter{
     
     public AlignController(){
         
     }
 
-
     @Override
-    public void setEnable(boolean enabled) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    public DriveCommand doFilter(DriveCommand input, RobotPose state) {
+        //here we do the logic to read sensors and all that.
+        //ideally, MOST sensor data is already availalbe in state.
+        return input;
     }
 
-    @Override
-    public boolean getEnabled() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
 
-    @Override
-    public DriveCommand filter(DriveCommand input, RobotPose state) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
 }

--- a/src/main/java/frc/robot/subsystems/AlignController.java
+++ b/src/main/java/frc/robot/subsystems/AlignController.java
@@ -10,13 +10,25 @@ package frc.robot.subsystems;
  * output: x and y control signals for drive
  * @author dcowden
  */
-public class AlignController {
+public class AlignController implements DriveFilter{
     
     public AlignController(){
         
     }
-    
-    public DriveCommand getOutput(DriveCommand input, RobotPose pose ){
-        return null;
+
+
+    @Override
+    public void setEnable(boolean enabled) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public boolean getEnabled() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public DriveCommand filter(DriveCommand input, RobotPose state) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/src/main/java/frc/robot/subsystems/DriveFilter.java
+++ b/src/main/java/frc/robot/subsystems/DriveFilter.java
@@ -1,5 +1,7 @@
 package frc.robot.subsystems;
 
+import frc.robot.core.RobotPose;
+
 /**
  * Base Drive Filter
  * @author dcowden

--- a/src/main/java/frc/robot/subsystems/DriveFilter.java
+++ b/src/main/java/frc/robot/subsystems/DriveFilter.java
@@ -8,13 +8,14 @@ import frc.robot.core.RobotPose;
  */
 public abstract class DriveFilter {
     private boolean enabled;
-    void setEnabled(boolean enabled){
+    
+    public void setEnabled(boolean enabled){
         this.enabled = enabled;
     }
-    boolean getEnabled(){
+    public boolean getEnabled(){
         return this.enabled;
     }
-    DriveCommand filter(DriveCommand input, RobotPose state){
+    public DriveCommand filter(DriveCommand input, RobotPose state){
         if ( this.enabled){
             return doFilter(input, state);
         }
@@ -22,6 +23,5 @@ public abstract class DriveFilter {
             return input;
         }
     }
-    
-    public abstract DriveCommand doFilter(DriveCommand input, RobotPose state);
+    abstract DriveCommand doFilter(DriveCommand input, RobotPose state);
 }

--- a/src/main/java/frc/robot/subsystems/DriveFilter.java
+++ b/src/main/java/frc/robot/subsystems/DriveFilter.java
@@ -1,11 +1,25 @@
 package frc.robot.subsystems;
 
 /**
- *
+ * Base Drive Filter
  * @author dcowden
  */
-public interface DriveFilter {
-    void setEnable(boolean enabled);
-    boolean getEnabled();
-    DriveCommand filter(DriveCommand input, RobotPose state);
+public abstract class DriveFilter {
+    private boolean enabled;
+    void setEnabled(boolean enabled){
+        this.enabled = enabled;
+    }
+    boolean getEnabled(){
+        return this.enabled;
+    }
+    DriveCommand filter(DriveCommand input, RobotPose state){
+        if ( this.enabled){
+            return doFilter(input, state);
+        }
+        else{
+            return input;
+        }
+    }
+    
+    public abstract DriveCommand doFilter(DriveCommand input, RobotPose state);
 }

--- a/src/main/java/frc/robot/subsystems/DriveFilter.java
+++ b/src/main/java/frc/robot/subsystems/DriveFilter.java
@@ -1,0 +1,11 @@
+package frc.robot.subsystems;
+
+/**
+ *
+ * @author dcowden
+ */
+public interface DriveFilter {
+    void setEnable(boolean enabled);
+    boolean getEnabled();
+    DriveCommand filter(DriveCommand input, RobotPose state);
+}

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -12,7 +12,7 @@ public class DriveSubsystem extends Subsystem{
     protected void initDefaultCommand() {
         m_robotDrive.driveCartesian(0.0, 0.0, 0.0);
     }
-    public void drive(double x, double y, double theta){
-        m_robotDrive.driveCartesian(x, y, theta);
+    public void drive(DriveCommand command){
+        m_robotDrive.driveCartesian(command.getX(),command.getY(), command.getZ());
     }
 }

--- a/src/main/java/frc/robot/subsystems/TwistLockDriveFilter.java
+++ b/src/main/java/frc/robot/subsystems/TwistLockDriveFilter.java
@@ -1,0 +1,21 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package frc.robot.subsystems;
+
+import frc.robot.core.RobotPose;
+
+/**
+ * SImply drops the z component
+ * @author dcowden
+ */
+public class TwistLockDriveFilter extends DriveFilter{
+
+    @Override
+    public DriveCommand doFilter(DriveCommand input, RobotPose state) {
+        return new DriveCommand(input.getX(), input.getY(), 0.0);          
+    }
+    
+}


### PR DESCRIPTION
@mandrews281 for example, this.

DO NOT merge this onto master. I flushed it out a bit to convince myself i like how it works, and i figured i'd share it with you-- but i wouldnt want to share this much code with the students.

this code replicates what was already there: the twist lock code already there is a very simple filter that ignores z when it is enabled.

I think this works ok for this season's need. You can chain filters together, and disable them ( in which case, the output should always be connected to the output directly. This version guarantees that this is the case by building that function into the base class.

My idea is that a dedicated subsystem is always computing a RobotPose, and making it available for all the subsystems. Right now, I just have the x , y, and angle values, which i think are probably enough for this season. In the more general case, the RobotPose might need to include the actual robot's position on the field, which would ultimately have to be updated somehow.  Ironically, the drive system might be responsible for doing this update ( since it can see the encoders), but for example this year, the vision system is better to do it)
I am imagining these other components that are not included in this commit:

*  the Operator Interface would grab joystick info and make a DriveInput object, which is the start of the pipeline
* a new subsystem would be created to compute and make the RobotPose available to everyone.
